### PR TITLE
Add optional sharding key to queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-typeorm-sharding-repository",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This module extends TypeORM capabilities to support distributed database environments with List and Range-based sharding strategies in a NestJS application.",
   "homepage": "https://github.com/rungwe/nestjs-typeorm-sharding-repository",
   "repository": {

--- a/src/repository-service/abstract-repository-service.ts
+++ b/src/repository-service/abstract-repository-service.ts
@@ -26,24 +26,24 @@ export interface AbstractRepositoryService<Entity> {
 
     update(
         criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>,
-        partialEntity: QueryDeepPartialEntity<Entity>
+        partialEntity: QueryDeepPartialEntity<Entity>, shardingKey?:string
     ): Promise<UpdateResult>;
 
     delete(
-        criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>
+        criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>, shardingKey?:string
     ): Promise<DeleteResult>;
 
-    count(options?: FindManyOptions<Entity>): Promise<number>;
-    countBy(where: FindOptionsWhere<Entity>): Promise<number>;
+    count(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<number>;
+    countBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<number>;
 
-    find(options?: FindManyOptions<Entity>): Promise<Entity[]>;
-    findBy(where: FindOptionsWhere<Entity>): Promise<Entity[]>;
+    find(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<Entity[]>;
+    findBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<Entity[]>;
 
-    findAndCount(options?: FindManyOptions<Entity>): Promise<[Entity[], number]>;
-    findAndCountBy(where: FindOptionsWhere<Entity>): Promise<[Entity[], number]>;
+    findAndCount(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<[Entity[], number]>;
+    findAndCountBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<[Entity[], number]>;
 
-    findOne(options: FindOneOptions<Entity>): Promise<Entity | null | undefined>;
-    findOneBy(where: FindOptionsWhere<Entity>): Promise<Entity | null | undefined>;
+    findOne(options: FindOneOptions<Entity>, shardingKey?:string): Promise<Entity | null | undefined>;
+    findOneBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<Entity | null | undefined>;
     findOneById(id: string | number | Date | ObjectID, shardingKey?: string): Promise<Entity | null>;
     findByIds(ids: any[], shardingKey?: string): Promise<Entity[]>;
 }

--- a/src/repository-service/sharding-repository-service.ts
+++ b/src/repository-service/sharding-repository-service.ts
@@ -7,7 +7,7 @@ import {
     UpdateResult,
     DeleteResult,
     FindManyOptions,
-    FindOneOptions,
+    FindOneOptions
 } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { AbstractRepositoryService } from './abstract-repository-service';
@@ -46,39 +46,40 @@ export class ShardingRepositoryService<
 
     async update(
         criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>,
-        partialEntity: QueryDeepPartialEntity<Entity>
+        partialEntity: QueryDeepPartialEntity<Entity>,
+        shardingKey?:string
     ): Promise<UpdateResult> {
-        return this.shardingEntityType.update(criteria, partialEntity);
+        return this.shardingEntityType.update(criteria, partialEntity, shardingKey);
     }
 
     async delete(
-        criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>
+        criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Entity>, shardingKey?:string
     ): Promise<DeleteResult> {
-        return this.shardingEntityType.delete(criteria);
+        return this.shardingEntityType.delete(criteria, shardingKey);
     }
 
-    async count(options?: FindManyOptions<Entity>): Promise<number> {
-        return this.shardingEntityType.count(options);
+    async count(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<number> {
+        return this.shardingEntityType.count(options, shardingKey);
     }
 
-    async countBy(where: FindOptionsWhere<Entity>): Promise<number> {
-        return this.shardingEntityType.countBy(where);
+    async countBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<number> {
+        return this.shardingEntityType.countBy(where, shardingKey);
     }
 
-    async find(options?: FindManyOptions<Entity>): Promise<Entity[]> {
-        return this.shardingEntityType.find(options);
+    async find(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<Entity[]> {
+        return this.shardingEntityType.find(options, shardingKey);
     }
 
-    async findBy(where: FindOptionsWhere<Entity>): Promise<Entity[]> {
-        return this.shardingEntityType.findBy(where);
+    async findBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<Entity[]> {
+        return this.shardingEntityType.findBy(where, shardingKey);
     }
 
-    async findAndCount(options?: FindManyOptions<Entity>): Promise<[Entity[], number]> {
-        return this.shardingEntityType.findAndCount(options);
+    async findAndCount(options?: FindManyOptions<Entity>, shardingKey?:string): Promise<[Entity[], number]> {
+        return this.shardingEntityType.findAndCount(options, shardingKey);
     }
 
-    async findAndCountBy(where: FindOptionsWhere<Entity>): Promise<[Entity[], number]> {
-        return this.shardingEntityType.findAndCountBy(where);
+    async findAndCountBy(where: FindOptionsWhere<Entity>, shardingKey?:string): Promise<[Entity[], number]> {
+        return this.shardingEntityType.findAndCountBy(where, shardingKey);
     }
 
     async findByIds(ids: any[], shardingKey?: string): Promise<Entity[]> {
@@ -89,11 +90,11 @@ export class ShardingRepositoryService<
         return this.shardingEntityType.findOneById(id, shardingKey);
     }
 
-    async findOne(options: FindOneOptions<Entity>): Promise<Entity | null | undefined> {
-        return this.shardingEntityType.findOne(options);
+    async findOne(options: FindOneOptions<Entity>, shardingKey?:string): Promise<Entity | null | undefined> {
+        return this.shardingEntityType.findOne(options, shardingKey);
     }
 
-    async findOneBy(where: FindOptionsWhere<Entity>): Promise<Entity | null | undefined> {
-        return this.shardingEntityType.findOneBy(where);
+    async findOneBy(where: FindOptionsWhere<Entity>, shardingKey?: string): Promise<Entity | null | undefined> {
+        return this.shardingEntityType.findOneBy(where, shardingKey);
     }
 }

--- a/src/test/nest.e2e.spec.ts
+++ b/src/test/nest.e2e.spec.ts
@@ -9,103 +9,379 @@ import { getRepositoryToken } from '../nest/util';
 
 
 describe('E2E Tests for ShardingModule', () => {
-  let app: INestApplication;
-  let caseService: CaseService;
-  let case4Repository: ShardingRepositoryService<Case4>;
-  let shardingManager: ShardingManager;
+    let app: INestApplication;
+    let caseService: CaseService;
+    let case4Repository: ShardingRepositoryService<Case4>;
+    let shardingManager: ShardingManager;
 
 
-  beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TestAppModule],
-      providers: [CaseService],
-    }).compile();
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [TestAppModule],
+            providers: [CaseService],
+        }).compile();
 
-    app = moduleFixture.createNestApplication();
-    caseService = app.get<CaseService>(CaseService);
-    const repositoryToken = getRepositoryToken(Case4);
-    console.log(repositoryToken)
-    case4Repository = app.get(repositoryToken);
-    shardingManager = app.get(ShardingManager);
+        app = moduleFixture.createNestApplication();
+        caseService = app.get<CaseService>(CaseService);
+        const repositoryToken = getRepositoryToken(Case4);
+        console.log(repositoryToken)
+        case4Repository = app.get(repositoryToken);
+        shardingManager = app.get(ShardingManager);
 
-    case4Repository.delete({});
-    await app.init();
-  });
+        case4Repository.delete({});
+        await app.init();
+    });
 
-  beforeEach(async () => {
-    await case4Repository.delete({});
-  });
-
-
-  it('should ensure service is defined', async () => {
-    expect(caseService).toBeDefined();
-  })
-
-  it('should ensure repository is defined', () => {
-    expect(case4Repository).toBeDefined();
-  });
-
-  it('should retrieve a repository service and interact with the database', async () => {
-    
-    const result = await caseService.findAllCases();
-    expect(result).toBeDefined();
-
-  });
-
-  it('should save entity in the db and be able to find it', async () => {
-    const case4: Case4 = new Case4()
-    case4.age = 4
-    case4.firstName = 'Foo';
-    case4.lastName = 'Bar';
-    case4.partner = 'test';
-
-    await caseService.saveCase(case4);
-
-    const cases = await caseService.findAllCases();
-    const count = await case4Repository.count();
-    expect(cases).toBeDefined();
-    expect(cases.length).toBe(1);
-    expect(count).toBe(1);
-
-  })
-
-  it('should save entity in the correct shard, default shard if there is no matching shard', async () => {
-    const case4: Case4 = new Case4()
-    case4.id = 100
-    case4.age = 4
-    case4.firstName = 'Foo';
-    case4.lastName = 'Bar';
-    case4.partner = 'test';
-
-    await caseService.saveCase(case4);
+    beforeEach(async () => {
+        await case4Repository.delete({});
+    });
 
 
-    expect((await shardingManager.getDataSourceByShardingKey('default').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBeDefined();
-    expect((await shardingManager.getDataSourceByShardingKey('partner1').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
-    expect((await shardingManager.getDataSourceByShardingKey('partner2').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
-    expect((await shardingManager.getDataSourceByShardingKey('partner3').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+    it('should ensure service is defined', async () => {
+        expect(caseService).toBeDefined();
+    })
 
-  });
+    it('should ensure repository is defined', () => {
+        expect(case4Repository).toBeDefined();
+    });
 
-  it('should save entity in the correct shard, the matching shard', async () => {
-    const matchingShardingKey = 'partner1'
-    const case4: Case4 = new Case4()
-    case4.id = 100
-    case4.age = 4
-    case4.firstName = 'Foo';
-    case4.lastName = 'Bar';
-    case4.partner = matchingShardingKey;
+    it('should retrieve a repository service and interact with the database', async () => {
 
-    await caseService.saveCase(case4);
+        const result = await caseService.findAllCases();
+        expect(result).toBeDefined();
+
+    });
+
+    it('should save entity in the db and be able to find it', async () => {
+        const case4: Case4 = new Case4()
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = 'test';
+
+        await caseService.saveCase(case4);
+
+        const cases = await caseService.findAllCases();
+        const count = await case4Repository.count();
+        expect(cases).toBeDefined();
+        expect(cases.length).toBe(1);
+        expect(count).toBe(1);
+
+    })
+
+    it('should save entity in the correct shard, default shard if there is no matching shard', async () => {
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = 'test';
+
+        await caseService.saveCase(case4);
 
 
-    expect((await shardingManager.getDataSourceByShardingKey('default').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
-    expect((await shardingManager.getDataSourceByShardingKey(matchingShardingKey).getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBeDefined();
-    expect((await shardingManager.getDataSourceByShardingKey('partner2').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
-    expect((await shardingManager.getDataSourceByShardingKey('partner3').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+        expect((await shardingManager.getDataSourceByShardingKey('default').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBeDefined();
+        expect((await shardingManager.getDataSourceByShardingKey('partner1').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+        expect((await shardingManager.getDataSourceByShardingKey('partner2').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+        expect((await shardingManager.getDataSourceByShardingKey('partner3').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
 
-  });
+    });
 
+    it('should save entity in the correct shard, the matching shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+
+
+        expect((await shardingManager.getDataSourceByShardingKey('default').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+        expect((await shardingManager.getDataSourceByShardingKey(matchingShardingKey).getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBeDefined();
+        expect((await shardingManager.getDataSourceByShardingKey('partner2').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+        expect((await shardingManager.getDataSourceByShardingKey('partner3').getRepository<Case4>(Case4).findOneBy({ id: case4.id }))).toBe(null);
+
+    });
+
+    // findOneByCase
+    it('should save entity in the correct shard, and find the matching record in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        const resultFromShardingKey = await caseService.findOneByCase({ id: case4.id }, matchingShardingKey);
+        expect(resultFromShardingKey).toBeDefined();
+        const findResults = await caseService.findOneByCase({ id: case4.id });
+        expect(findResults).toBeDefined();
+        const partner2Result = await caseService.findOneByCase({ id: case4.id }, 'partner2');
+        expect(partner2Result).toBe(null);
+        const partner3Result = await caseService.findOneByCase({ id: case4.id }, 'partner3');
+        expect(partner3Result).toBe(null);
+
+    });
+    // findCasesBy
+    it('should save entities in the correct shard, and find by the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const recordsFromShardingKey = await caseService.findCasesBy({ age: case4.age }, matchingShardingKey);
+        expect(recordsFromShardingKey).toBeDefined();
+        expect(recordsFromShardingKey.length).toBe(2);
+        const defaultRecords = await caseService.findCasesBy({ age: case4.age }, 'default');
+        const recordsNoShardingKey = await caseService.findCasesBy({ age: case4.age });
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+        expect(recordsNoShardingKey).toBeDefined();
+        expect(recordsNoShardingKey.length).toBe(2);
+    });
+    // findCases
+    it('should save entities in the correct shard, and find the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const recordsFromShardingKey = await caseService.findCases({ where: { age: case4.age } }, matchingShardingKey);
+        expect(recordsFromShardingKey).toBeDefined();
+        expect(recordsFromShardingKey.length).toBe(2);
+        const defaultRecords = await caseService.findCases({ where: { age: case4.age } }, 'default');
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+    });
+    // countCases
+    it('should save entities in the correct shard, and count the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const recordsFromShardingKeyCount = await caseService.countCases({ where: { age: case4.age } }, matchingShardingKey);
+        expect(recordsFromShardingKeyCount).toBe(2);
+        const defaultRecordsCount = await caseService.countCases({ where: { age: case4.age } }, 'default');
+        expect(defaultRecordsCount).toBe(0);
+        const recordsNoShardingKeyCount = await caseService.countCases({ where: { age: case4.age } });
+        expect(recordsNoShardingKeyCount).toBe(2);
+    });
+    // countCasesBy
+    it('should save entities in the correct shard, and count the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const recordsFromShardingKeyCount = await caseService.countCasesBy({ age: case4.age }, matchingShardingKey);
+        expect(recordsFromShardingKeyCount).toBe(2);
+        const defaultRecordsCount = await caseService.countCasesBy({ age: case4.age }, 'default');
+        expect(defaultRecordsCount).toBe(0);
+        const recordsNoShardingKeyCount = await caseService.countCasesBy({ age: case4.age });
+        expect(recordsNoShardingKeyCount).toBe(2);
+    });
+    // findAndCountCases
+    it('should save entities in the correct shard, and find and count the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const [records, count] = await caseService.findAndCountCases({ where: { age: case4.age } }, matchingShardingKey);
+        expect(records).toBeDefined();
+        expect(records.length).toBe(2);
+        expect(count).toBe(2);
+        const [defaultRecords, defaultCount] = await caseService.findAndCountCases({ where: { age: case4.age } }, 'default');
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+        expect(defaultCount).toBe(0);
+        const [recordsNoShardingKey, noShardingKeyCount] = await caseService.findAndCountCases({ where: { age: case4.age } });
+        expect(recordsNoShardingKey[0]).toBeDefined();
+        expect(recordsNoShardingKey.length).toBe(2);
+        expect(noShardingKeyCount).toBe(2);
+    });
+    // findAndCountCasesBy
+    it('should save entities in the correct shard, and find and count the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const [records, count] = await caseService.findAndCountCasesBy({ age: case4.age }, matchingShardingKey);
+        expect(records).toBeDefined();
+        expect(records.length).toBe(2);
+        expect(count).toBe(2);
+        const [defaultRecords, defaultCount] = await caseService.findAndCountCasesBy({ age: case4.age }, 'default');
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+        expect(defaultCount).toBe(0);
+        const [recordsNoShardingKey, noShardingKeyCount] = await caseService.findAndCountCasesBy({ age: case4.age });
+        expect(recordsNoShardingKey[0]).toBeDefined();
+        expect(recordsNoShardingKey.length).toBe(2);
+        expect(noShardingKeyCount).toBe(2);
+    });
+    // updateCase
+    it('should save entities in the correct shard, and update the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const updateResult = await caseService.updateCase({ age: case4.age }, { age: 5 }, matchingShardingKey);
+        expect(updateResult).toBeDefined();
+        const updatedRecords = await caseService.findCases({ where: { age: 5 } }, matchingShardingKey);
+        expect(updatedRecords).toBeDefined();
+        expect(updatedRecords.length).toBe(2);
+        const defaultRecords = await caseService.findCases({ where: { age: 5 }, }, 'default');
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+    });
+    // deleteCase
+    it('should save entities in the correct shard, and delete the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const deleteResult = await caseService.deleteCase({ age: case4.age }, matchingShardingKey);
+        expect(deleteResult).toBeDefined();
+        const deletedRecords = await caseService.findCases({ where: { age: case4.age } }, matchingShardingKey);
+        expect(deletedRecords).toBeDefined();
+        expect(deletedRecords.length).toBe(0);
+        const defaultRecords = await caseService.findCases({ where: { age: case4.age } }, 'default');
+        expect(defaultRecords).toBeDefined();
+        expect(defaultRecords.length).toBe(0);
+    });
+    // findOneCase
+    it('should save entities in the correct shard, and find the matching records in the correct shard', async () => {
+        const matchingShardingKey = 'partner1'
+        const case4: Case4 = new Case4()
+        case4.id = 100
+        case4.age = 4
+        case4.firstName = 'Foo';
+        case4.lastName = 'Bar';
+        case4.partner = matchingShardingKey;
+
+        const case4Two: Case4 = new Case4()
+        case4Two.id = 101
+        case4Two.age = 4
+        case4Two.firstName = 'Foo';
+        case4Two.lastName = 'Bar';
+        case4Two.partner = matchingShardingKey;
+
+        await caseService.saveCase(case4);
+        await caseService.saveCase(case4Two);
+        const resultFromShardingKey = await caseService.findOneCase({ where: { id: case4.id } }, matchingShardingKey);
+        expect(resultFromShardingKey).toBeDefined();
+        const findResults = await caseService.findOneCase({ where: { id: case4.id } });
+        expect(findResults).toBeDefined();
+        const partner2Result = await caseService.findOneCase({ where: { id: case4.id }, }, 'partner2');
+        expect(partner2Result).toBe(null);
+        const partner3Result = await caseService.findOneCase({ where: { id: case4.id }, }, 'partner3');
+        expect(partner3Result).toBe(null);
+    });
   // Additional tests...
 
   afterAll(async () => {

--- a/src/test/service/case-service.ts
+++ b/src/test/service/case-service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '../../nest/decorators';
 import { Case4 } from '../entity/case4';
 import { ShardingRepositoryService } from '../../repository-service/sharding-repository-service';
+import { DeleteResult, FindManyOptions, FindOneOptions, FindOptionsWhere, ObjectID, UpdateResult } from 'typeorm';
 
 @Injectable()
 export class CaseService {
@@ -11,12 +12,52 @@ export class CaseService {
   ) {}
 
 
-  async findAllCases(): Promise<Case4[]> {
-    return this.caseRepository.find();
+  async findAllCases(shardingKey?:string): Promise<Case4[]> {
+    return this.caseRepository.find({}, shardingKey);
   }
 
   async saveCase(case4: Case4): Promise<void> {
    await this.caseRepository.save(case4)
+  }
+
+  async updateCase(criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Case4>, partialEntity: any, shardingKey?: string): Promise<UpdateResult> {
+      return await this.caseRepository.update(criteria, partialEntity, shardingKey);
+  }
+
+  async deleteCase(criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOptionsWhere<Case4>, shardingKey?: string): Promise<DeleteResult> {
+      return await this.caseRepository.delete(criteria, shardingKey);
+  }
+
+  async findOneCase(options: FindOneOptions<Case4>, shardingKey?: string): Promise<Case4 | null | undefined> {
+      return this.caseRepository.findOne(options, shardingKey);
+  }
+
+  async findOneByCase(where: FindOptionsWhere<Case4>, shardingKey?: string): Promise<Case4 | null | undefined> {
+    return this.caseRepository.findOneBy(where, shardingKey);
+  }
+
+  async findCasesBy(where: FindOptionsWhere<Case4>, shardingKey?: string): Promise<Case4[]> {
+    return this.caseRepository.findBy(where, shardingKey);
+  }
+
+  async findCases(options: FindManyOptions<Case4>, shardingKey?: string): Promise<Case4[]> {
+    return this.caseRepository.find(options, shardingKey);
+  }
+
+  async countCasesBy(where: FindOptionsWhere<Case4>, shardingKey?: string): Promise<number> {
+      return this.caseRepository.countBy(where, shardingKey);
+  }
+
+  async countCases(options?: FindManyOptions<Case4>, shardingKey?: string): Promise<number> {
+      return this.caseRepository.count(options, shardingKey);
+  }
+
+  async findAndCountCasesBy(where: FindOptionsWhere<Case4>, shardingKey?: string): Promise<[Case4[], number]> {
+      return this.caseRepository.findAndCountBy(where, shardingKey);
+  }
+
+  async findAndCountCases(options?: FindManyOptions<Case4>, shardingKey?: string): Promise<[Case4[], number]> {
+    return this.caseRepository.findAndCount(options, shardingKey);
   }
 
 }


### PR DESCRIPTION
- Add optional sharding key to the repository queries. This allows running queries against a specific datasource.
- Update end to end tests
- Update the README.md